### PR TITLE
SRE-3138 apt repo update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 php\_wrapper
 ======
 
+3.3.0
+-----
+* Use token authentication for artifactory
+
 3.2.0
 -----
 * Use private repo for php7.1 packages as well

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ php\_wrapper
 
 3.3.0
 -----
-* Use token authentication for artifactory
+* Use encrypted password authentication for artifactory
 
 3.2.0
 -----

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "59fc6554e055a1a5b94a9dc349602e47c3374e6789972a9284699071b4398a03",
+  "revision_id": "34c8cc3d819050005141ca11860cfe7f70e8d39858905e5eb57b84adeb4c5392",
   "name": "php_wrapper",
   "run_list": [
     "recipe[php_wrapper::default]",
@@ -8,19 +8,18 @@
   "cookbook_locks": {
     "php_wrapper": {
       "version": "3.3.0",
-      "identifier": "b6bd5f340870586d96363a4e01b072259e888f36",
-      "dotted_decimal_identifier": "51436662353850456.30845932112052656.125505899106102",
+      "identifier": "a89237f89fa7052dff661774321c5cdc1db8c7b0",
+      "dotted_decimal_identifier": "47448565179459333.12947187897217564.102100461209520",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
         "remote": null,
-        "revision": "5bfbba8c45858c0b4e4c1144ee4e9a176c8a1d1e",
+        "revision": "a30b6a4b9ac105023eacd3ce836339620e91b2fd",
         "working_tree_clean": false,
-        "published": true,
+        "published": false,
         "synchronized_remote_branches": [
-          "origin/HEAD -> origin/master",
-          "origin/master"
+
         ]
       },
       "source_options": {
@@ -58,6 +57,17 @@
       "source_options": {
         "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/php/versions/4.0.0/download",
         "version": "4.0.0"
+      }
+    },
+    "apt": {
+      "version": "5.1.0",
+      "identifier": "8a4885b9e5b79c7148d7eabd4a39fb2a68c77d04",
+      "dotted_decimal_identifier": "38923285972760476.31886764561746489.276159565102340",
+      "cache_key": "apt-5.1.0-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/apt/versions/5.1.0/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/apt/versions/5.1.0/download",
+        "version": "5.1.0"
       }
     },
     "build-essential": {
@@ -115,6 +125,17 @@
         "version": "2.1.0"
       }
     },
+    "compat_resource": {
+      "version": "12.19.1",
+      "identifier": "e83881cec71c93482a721e30c09eaa1b057ddd8f",
+      "dotted_decimal_identifier": "65364324767964307.20312867944317086.187033032973711",
+      "cache_key": "compat_resource-12.19.1-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/compat_resource/versions/12.19.1/download",
+      "source_options": {
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/compat_resource/versions/12.19.1/download",
+        "version": "12.19.1"
+      }
+    },
     "ohai": {
       "version": "5.3.0",
       "identifier": "3ad58179813321f2497a12ea4e2bbb6018a47ee3",
@@ -152,6 +173,10 @@
         "= 4.0.0"
       ],
       [
+        "apt",
+        "= 5.1.0"
+      ],
+      [
         "build-essential",
         "= 8.2.1"
       ],
@@ -172,6 +197,10 @@
         "= 2.1.0"
       ],
       [
+        "compat_resource",
+        "= 12.19.1"
+      ],
+      [
         "ohai",
         "= 5.3.0"
       ]
@@ -181,6 +210,10 @@
         [
           "php",
           "~> 4.0.0"
+        ],
+        [
+          "apt",
+          "~> 5.1.0"
         ]
       ],
       "seven_zip (2.0.2)": [
@@ -213,6 +246,12 @@
           ">= 0.0.0"
         ]
       ],
+      "apt (5.1.0)": [
+        [
+          "compat_resource",
+          ">= 12.16.3"
+        ]
+      ],
       "build-essential (8.2.1)": [
         [
           "seven_zip",
@@ -240,6 +279,9 @@
           "seven_zip",
           ">= 0.0.0"
         ]
+      ],
+      "compat_resource (12.19.1)": [
+
       ],
       "ohai (5.3.0)": [
 

--- a/Policyfile.lock.json
+++ b/Policyfile.lock.json
@@ -1,5 +1,5 @@
 {
-  "revision_id": "27d8b0e8c706bb5753a5571823492ff5cb08e826c4f7fb196e5ca3d70b087cc1",
+  "revision_id": "59fc6554e055a1a5b94a9dc349602e47c3374e6789972a9284699071b4398a03",
   "name": "php_wrapper",
   "run_list": [
     "recipe[php_wrapper::default]",
@@ -7,15 +7,15 @@
   ],
   "cookbook_locks": {
     "php_wrapper": {
-      "version": "3.2.0",
-      "identifier": "5127fd447a3c9f049b529aec19487f0844673a69",
-      "dotted_decimal_identifier": "22843441842633887.1296678995630408.139673484081769",
+      "version": "3.3.0",
+      "identifier": "b6bd5f340870586d96363a4e01b072259e888f36",
+      "dotted_decimal_identifier": "51436662353850456.30845932112052656.125505899106102",
       "source": ".",
       "cache_key": null,
       "scm_info": {
         "scm": "git",
-        "remote": "git@github.com:lightspeedretail/chef-php-wrapper.git",
-        "revision": "65c2f8b27140105d23fd3770b27e8d7b4bff9d7e",
+        "remote": null,
+        "revision": "5bfbba8c45858c0b4e4c1144ee4e9a176c8a1d1e",
         "working_tree_clean": false,
         "published": true,
         "synchronized_remote_branches": [
@@ -116,14 +116,14 @@
       }
     },
     "ohai": {
-      "version": "5.2.5",
-      "identifier": "f393ae21b9c53af8a3ee75662fce43f3c2ce5167",
-      "dotted_decimal_identifier": "68560795440104762.69986038791417806.74714224415079",
-      "cache_key": "ohai-5.2.5-supermarket.chef.io",
-      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/ohai/versions/5.2.5/download",
+      "version": "5.3.0",
+      "identifier": "3ad58179813321f2497a12ea4e2bbb6018a47ee3",
+      "dotted_decimal_identifier": "16560300715225889.68197733016161835.206021404688099",
+      "cache_key": "ohai-5.3.0-supermarket.chef.io",
+      "origin": "https://supermarket.chef.io:443/api/v1/cookbooks/ohai/versions/5.3.0/download",
       "source_options": {
-        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/ohai/versions/5.2.5/download",
-        "version": "5.2.5"
+        "artifactserver": "https://supermarket.chef.io:443/api/v1/cookbooks/ohai/versions/5.3.0/download",
+        "version": "5.3.0"
       }
     }
   },
@@ -173,11 +173,11 @@
       ],
       [
         "ohai",
-        "= 5.2.5"
+        "= 5.3.0"
       ]
     ],
     "dependencies": {
-      "php_wrapper (3.2.0)": [
+      "php_wrapper (3.3.0)": [
         [
           "php",
           "~> 4.0.0"
@@ -241,7 +241,7 @@
           ">= 0.0.0"
         ]
       ],
-      "ohai (5.2.5)": [
+      "ohai (5.3.0)": [
 
       ]
     }

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'pg.omni.devops@lightspeedhq.com'
 license          'Apache 2.0'
 description      'Installs/Configures php_wrapper'
 long_description 'Installs/Configures php_wrapper'
-version          '3.2.0'
+version          '3.3.0'
 source_url       'https://github.com/lightspeedretail/chef-php-wrapper'
 issues_url       'https://github.com/lightspeedretail/chef-php-wrapper/issues'
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -9,3 +9,4 @@ source_url       'https://github.com/lightspeedretail/chef-php-wrapper'
 issues_url       'https://github.com/lightspeedretail/chef-php-wrapper/issues'
 
 depends 'php', '~> 4.0.0'
+depends 'apt', '~> 5.1.0'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -1,23 +1,25 @@
 # Install PHP 7.1 from PPA
 #
 apt_repository 'php7.1' do
-  distribution node['lsb']['codename']
-  uri "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian"
-  key "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian/mirror.cs.uchicago.edu.gpg"
-  components ['main']
-  arch 'amd64'
-  trusted true
-  only_if { node['php']['version'].start_with?('7') }
+  distribution  node['lsb']['codename']
+  uri           "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian"
+  key           "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian/mirror.cs.uchicago.edu.gpg"
+  components    ['main']
+  arch          'amd64'
+  repo_name     'jfrog-lightspeedhq-debian-php71'
+  trusted       true
+  only_if       { node['php']['version'].start_with?('7') }
 end
 
 apt_repository 'php5.6' do
-  distribution node['lsb']['codename']
-  uri "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian"
-  key "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian/mirror.cs.uchicago.edu.gpg"
-  components ['main']
-  arch 'amd64'
-  trusted true
-  only_if { node['php']['version'].start_with?('5.6') }
+  distribution  node['lsb']['codename']
+  uri           "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian"
+  key           "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian/mirror.cs.uchicago.edu.gpg"
+  components    ['main']
+  arch          'amd64'
+  repo_name     'jfrog-lightspeedhq-debian-php56'
+  trusted       true
+  only_if       { node['php']['version'].start_with?('5.6') }
 end
 
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -6,7 +6,6 @@ apt_repository 'php7.1' do
   key           "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian/mirror.cs.uchicago.edu.gpg"
   components    ['main']
   arch          'amd64'
-  repo_name     'jfrog-lightspeedhq-debian-php71'
   trusted       true
   only_if       { node['php']['version'].start_with?('7') }
 end
@@ -17,7 +16,6 @@ apt_repository 'php5.6' do
   key           "https://#{node['apt_repo']['lightspeedhq']['username']}:#{node['apt_repo']['lightspeedhq']['password']}@lightspeedhq.jfrog.io/lightspeedhq/debian/mirror.cs.uchicago.edu.gpg"
   components    ['main']
   arch          'amd64'
-  repo_name     'jfrog-lightspeedhq-debian-php56'
   trusted       true
   only_if       { node['php']['version'].start_with?('5.6') }
 end


### PR DESCRIPTION
Updated cookbook to depend on `apt 5.1.0` which will name the repository configuration file as the name specified in the module. The encrypted password for the `ls-ro` user will be updated in the chef databags under the existing `['apt_repo']['lightspeedhq']['password']` key.